### PR TITLE
fix: revert change for create_user_account params

### DIFF
--- a/linkdrop/src/create_user_account.rs
+++ b/linkdrop/src/create_user_account.rs
@@ -4,12 +4,8 @@ use near_sdk::{AccountId, Gas, PublicKey};
 #[near_bindgen]
 impl Linkdrop {
   #[payable]
-  pub fn create_user_account(public_key: PublicKey) -> Promise {
-    let account_id = AccountId::new_unchecked(format!(
-      "{}.{}",
-      env::signer_account_id(),
-      env::current_account_id()
-    ));
+  pub fn create_user_account(name: AccountId, public_key: PublicKey) -> Promise {
+    let account_id = AccountId::new_unchecked(format!("{}.{}", name, env::current_account_id()));
 
     Promise::new(account_id)
       .create_account()


### PR DESCRIPTION
I didn't actually address https://github.com/NEAR-labs/contracts.near-linkdrop/pull/1#discussion_r701681858 yet before you pulled in because I was away for the weekend. Here is reverting that change.